### PR TITLE
Run CI on pushes to master in addition to PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,9 @@ name: Continuous Integration
 
 on:
   pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   check-build:


### PR DESCRIPTION
## Summary
- Adds a `push` trigger for the `master` branch to `.github/workflows/build.yml` so CI runs on merges to master, not only on pull requests.

## Test plan
- [ ] After merge, confirm a CI run is triggered on the resulting push to `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)