### PR TITLE
Add help target and .PHONY declarations to all makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,38 +1,55 @@
 # Top-level build driver for the CMOC OS-9 library, tests, and utilities.
 
 .PHONY: all libs tests utils clean clean-libs clean-tests clean-utils dsk run \
-        lib cgfx unittest
+        lib cgfx unittest help
 
+# Build libs, tests, and utils (default target)
 all: libs tests utils
 
+# Build the lib/ and cgfx/ static libraries
 libs: lib cgfx
 
+# Build the lib/ static library (libc.a, libcf.a)
 lib:
 	$(MAKE) -C lib
 
+# Build the cgfx/ static library (libcgfx.a)
 cgfx:
 	$(MAKE) -C cgfx
 
+# Build the unit tests (depends on libs)
 tests: libs
 	$(MAKE) -C unittest
 
+# Build the utils (depends on libs)
 utils: libs
 	$(MAKE) -C utils
 
+# Build the unit tests and pack them into a bootable test.dsk image
 dsk: libs
 	$(MAKE) -C unittest dsk
 
+# Build test.dsk and launch MAME to run the unit tests
 run: libs
 	$(MAKE) -C unittest run
 
+# Remove build artifacts in libs, tests, and utils
 clean: clean-tests clean-utils clean-libs
 
+# Remove build artifacts in cgfx/ and lib/
 clean-libs:
 	$(MAKE) -C cgfx clean
 	$(MAKE) -C lib clean
 
+# Remove build artifacts in unittest/
 clean-tests:
 	$(MAKE) -C unittest clean
 
+# Remove build artifacts in utils/
 clean-utils:
 	$(MAKE) -C utils clean
+
+# Display this help message listing available phony targets
+help:
+	@echo "Available targets:"
+	@awk 'BEGIN{c=""} /^# /{c=substr($$0,3); next} /^[a-zA-Z_][a-zA-Z0-9_.-]*:/{if(c!=""){t=$$1; sub(/:.*/,"",t); printf "  %-20s %s\n", t, c}; c=""; next} {c=""}' $(MAKEFILE_LIST)

--- a/cgfx/Makefile
+++ b/cgfx/Makefile
@@ -8,15 +8,25 @@ CMOC_CPP = --cpp="cpp -Wno-builtin-macro-redefined"
 CFLAGS = $(CMOC_CPP) --os9 -I../include -I./include
 ASOUT = --obj -o
 
+.PHONY: all dskclean clean help
+
 %.o: %.as
 	$(ASM) $(AFLAGS) $< $(ASOUT)$@
 
+# Build libcgfx.a (default target)
 all:	libcgfx.a
 
 libcgfx.a: $(MODS)
 	lwar -c $@ $(MODS)
 
+# Alias for clean (removes build artifacts including disk images)
 dskclean: clean
 
+# Remove build artifacts
 clean:
 	$(RM) *.o *.list *.map libcgfx.a
+
+# Display this help message listing available phony targets
+help:
+	@echo "Available targets:"
+	@awk 'BEGIN{c=""} /^# /{c=substr($$0,3); next} /^[a-zA-Z_][a-zA-Z0-9_.-]*:/{if(c!=""){t=$$1; sub(/:.*/,"",t); printf "  %-20s %s\n", t, c}; c=""; next} {c=""}' $(MAKEFILE_LIST)

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -39,6 +39,9 @@ FLOAT_MODS = $(COMMON_MODS) pflinit.o pffinit.o $(FLOAT_SUPPORT)
 BASE_OBJS = $(addprefix $(OBJDIR_BASE)/,$(BASE_MODS))
 FLOAT_OBJS = $(addprefix $(OBJDIR_FLOAT)/,$(FLOAT_MODS))
 
+.PHONY: all dskclean clean help
+
+# Build libc.a and libcf.a (default target)
 all: libc.a libcf.a
 
 libc.a: $(BASE_OBJS)
@@ -71,8 +74,15 @@ $(OBJDIR_BASE)/%.o: %.asm | $(OBJDIR_BASE)
 $(OBJDIR_FLOAT)/%.o: %.asm | $(OBJDIR_FLOAT)
 	cd $(OBJDIR_FLOAT) && $(ASM) $(AFLAGS) ../$< $(ASOUT)$(@F)
 
+# Alias for clean (removes build artifacts including disk images)
 dskclean: clean
 
+# Remove build artifacts
 clean:
 	$(RM) -r $(OBJDIR_BASE) $(OBJDIR_FLOAT)
 	$(RM) *.o *.list *.map libc.a libcf.a
+
+# Display this help message listing available phony targets
+help:
+	@echo "Available targets:"
+	@awk 'BEGIN{c=""} /^# /{c=substr($$0,3); next} /^[a-zA-Z_][a-zA-Z0-9_.-]*:/{if(c!=""){t=$$1; sub(/:.*/,"",t); printf "  %-20s %s\n", t, c}; c=""; next} {c=""}' $(MAKEFILE_LIST)

--- a/unittest/Makefile
+++ b/unittest/Makefile
@@ -36,8 +36,12 @@ GRAPHICS_TESTS = wintest maze
 TESTS	= abortchild aborttest attrwraptest compat3test ctypetest datmodstest defdrivetest dirapitest dirtest errmsgtest fdstreamtest filelayout fiotest floatfmttest floattest forkhellotest forknooptest forknowaittest forktest getopttest gtest hello intercepttest intmathtest iotest lmultest longtest memtest misctest noop osgstattest osiotest osopenerrtest popentest printtest pwcryptest pwenttest randtest searchtest setbuftest setjmptest setstest signaltest skiptest sleeptest stdioedgetest stdlibtest streamiotest stringexttest stringtest structcopytest syscalltest systemtest timetest utimetest
 ALL_TESTS = $(TESTS) $(GRAPHICS_TESTS)
 
+.PHONY: all dsk run clean help
+
+# Build all unit tests (default target)
 all:	$(ALL_TESTS)
 
+# Build all tests and pack them into a bootable test.dsk image
 dsk:	all
 	os9 format -e -q -ds -dd -t80 test.dsk
 	os9 makdir test.dsk,CMDS
@@ -48,9 +52,16 @@ dsk:	all
 	os9 copy -l go test.dsk,
 
 
+# Build test.dsk and launch MAME to run the tests
 run:	dsk
 	mame64 -inipath ~/Documents/mame -video opengl -window coco3 -flop1 nos9.dsk -flop2 test.dsk -speed 4 &
 
+# Remove built tests, the disk image, and intermediate artifacts
 clean:
 	-rm -f $(ALL_TESTS) test.dsk go
 	-rm -f *.s.list *.s.map
+
+# Display this help message listing available phony targets
+help:
+	@echo "Available targets:"
+	@awk 'BEGIN{c=""} /^# /{c=substr($$0,3); next} /^[a-zA-Z_][a-zA-Z0-9_.-]*:/{if(c!=""){t=$$1; sub(/:.*/,"",t); printf "  %-20s %s\n", t, c}; c=""; next} {c=""}' $(MAKEFILE_LIST)

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -9,14 +9,21 @@ SUBDIRS = uemacs ed
 
 UTILS = wc cat head cmp tr cut echo sleep tee rev strings cksum uniq comm split paste seq basename dirname true false yes tail sync tty mkdir rmdir
 
-.PHONY: all clean $(SUBDIRS)
+.PHONY: all clean help $(SUBDIRS)
 
+# Build all utility binaries and subdirectory utils (default target)
 all: $(UTILS) $(SUBDIRS)
 
 $(SUBDIRS):
 	$(MAKE) -C $@
 
+# Remove built utility binaries and clean each subdirectory
 clean:
 	-rm -f $(UTILS)
 	-rm -f *.s.list *.s.map
 	$(foreach dir,$(SUBDIRS),$(MAKE) -C $(dir) clean;)
+
+# Display this help message listing available phony targets
+help:
+	@echo "Available targets:"
+	@awk 'BEGIN{c=""} /^# /{c=substr($$0,3); next} /^[a-zA-Z_][a-zA-Z0-9_.-]*:/{if(c!=""){t=$$1; sub(/:.*/,"",t); printf "  %-20s %s\n", t, c}; c=""; next} {c=""}' $(MAKEFILE_LIST)

--- a/utils/ed/makefile
+++ b/utils/ed/makefile
@@ -9,6 +9,9 @@ OFILES = amatch.o append.o bitmap.o catsub.o ckglob.o deflt.o del.o docmd.o \
 	gettxt.o ins.o join.o makepat.o maksub.o matchs.o move.o omatch.o \
 	optpat.o set.o setbuf.o subst.o unmkpat.o
 
+.PHONY: all clean help
+
+# Build the ed editor (default target)
 all: ed
 
 ed: $(OFILES)
@@ -17,5 +20,11 @@ ed: $(OFILES)
 %.o: %.c
 	$(DCC) $(DCCFLAGS) --compile -o $@ $<
 
+# Remove ed binary, object files, and listings
 clean:
 	rm -f ed $(OFILES) *.list *.map
+
+# Display this help message listing available phony targets
+help:
+	@echo "Available targets:"
+	@awk 'BEGIN{c=""} /^# /{c=substr($$0,3); next} /^[a-zA-Z_][a-zA-Z0-9_.-]*:/{if(c!=""){t=$$1; sub(/:.*/,"",t); printf "  %-20s %s\n", t, c}; c=""; next} {c=""}' $(MAKEFILE_LIST)

--- a/utils/rogue_epyx_c/Makefile
+++ b/utils/rogue_epyx_c/Makefile
@@ -13,6 +13,9 @@ SRCS = main.c epyx_arena.c epyx_format.c epyx_screen.c rogue_game.c
 ASRCS = rogue_signal.as
 OBJS = $(SRCS:.c=.o) $(ASRCS:.as=.o)
 
+.PHONY: all clean help
+
+# Build the rogue executable along with its data files (default target)
 all: $(PROGRAM) rogue.dat rogue.hlp rogue.chr rogue.scr
 
 $(PROGRAM): $(OBJS)
@@ -36,5 +39,11 @@ rogue.scr: $(ROGUE_SCR_SRC)
 %.o: %.as
 	$(LWASM) $(ASFLAGS) -o$@ $<
 
+# Remove the executable, data files, and intermediate artifacts
 clean:
 	rm -f $(PROGRAM) rogue.dat rogue.hlp rogue.chr rogue.scr *.o *.s *.list *.map
+
+# Display this help message listing available phony targets
+help:
+	@echo "Available targets:"
+	@awk 'BEGIN{c=""} /^# /{c=substr($$0,3); next} /^[a-zA-Z_][a-zA-Z0-9_.-]*:/{if(c!=""){t=$$1; sub(/:.*/,"",t); printf "  %-20s %s\n", t, c}; c=""; next} {c=""}' $(MAKEFILE_LIST)

--- a/utils/uemacs/makefile
+++ b/utils/uemacs/makefile
@@ -16,9 +16,11 @@ RESTO  = uebasic.o uebuffer1.o uebuffer2.o uefile1.o uefile2.o uefileio.o \
   uetermio.o uecoco.o uewindow.o ueword.o
 OFILES = $(MAINO) $(DISPO) $(RESTO)
 
+.PHONY: all clean help
+
+# Build the umacs editor (default target)
 all: umacs
 
-# use cio libarary
 umacs: $(OFILES)
 	$(DCC) $(DCCFLAGS) -o $@ $^ $(LDFLAGS)
 
@@ -30,6 +32,12 @@ $(RESTO): ueed.h
 	@mkdir -p $(CMOC_INTDIR)/$*
 	$(DCC) $(DCCFLAGS) --intermediate --intdir=$(CMOC_INTDIR)/$* --compile -o $@ $<
 
+# Remove umacs binary, intermediates, and listings
 clean:
 	$(RM) -r $(CMOC_INTDIR)
 	$(RM) $(OFILES) umacs *.list *.map c.errors cstr.* ctmp.*
+
+# Display this help message listing available phony targets
+help:
+	@echo "Available targets:"
+	@awk 'BEGIN{c=""} /^# /{c=substr($$0,3); next} /^[a-zA-Z_][a-zA-Z0-9_.-]*:/{if(c!=""){t=$$1; sub(/:.*/,"",t); printf "  %-20s %s\n", t, c}; c=""; next} {c=""}' $(MAKEFILE_LIST)

--- a/utils/uucpbb/makefile
+++ b/utils/uucpbb/makefile
@@ -85,11 +85,15 @@ login_OBJS = login.o parse.o fixperms.o pwent.o getenv.o strdup.o
 cnvrtmail_OBJS = cnvrtmail.o docmd.o fixperms.o gtime.o strupr.o getval.o \
 	mfgets.o filemove.o getenv.o parse.o pwent.o strdup.o
 
-# Make all components
+.PHONY: all cmoc-all sizes banner clean dsk dskcopy dskclean info help
+
+# Build all UUCPbb commands (default target)
 all: cmoc-all
 
+# Build the cmoc-compiled UUCPbb commands
 cmoc-all: $(CMOC_TARGETS)
 
+# Print the size in bytes of each built UUCPbb command
 sizes: cmoc-all
 	@printf "%-16s %10s\n" "command" "cmoc"
 	@for cmd in $(SRC_CMDS); do \
@@ -97,6 +101,7 @@ sizes: cmoc-all
 			"`wc -c < $(CMOC_OUTDIR)/$$cmd`"; \
 	done
 
+# Print the UUCPbb banner
 banner:
 	@$(ECHO) "**************************************************"
 	@$(ECHO) "*                                                *"
@@ -104,11 +109,12 @@ banner:
 	@$(ECHO) "*                                                *"
 	@$(ECHO) "**************************************************"
 
-# Clean all components
+# Remove the build directory, disk images, and intermediate artifacts
 clean:	dskclean
 	$(RM) -r $(BUILDDIR)
 	$(RM) c.errors *.list *.map cstr.* ctmp.*
 
+# Build the 6809 and 6309 UUCPbb disk images
 dsk: $(DSKS)
 
 $(DISK68): banner all
@@ -163,15 +169,23 @@ $(DISK63): banner all
 	$(CD) doc; $(CPL) $(DOCS) ../$@,UUCP/DOC
 	$(CPL) copying readme.first $@,UUCP
 
+# Copy built disk images to $(DSKDIR)
 dskcopy: dsk
 	$(CP) $(DSKS) $(DSKDIR)
 
+# Remove the built disk images
 dskclean:
 	$(RM) $(DSKS)
 
+# Display the UUCPbb version and the disk image names
 info:
 	@$(ECHO) "*** UUCPbb 2.1 ***"
 	@$(foreach dsk, $(DSKS), $(ECHO) $(dsk);)
+
+# Display this help message listing available phony targets
+help:
+	@echo "Available targets:"
+	@awk 'BEGIN{c=""} /^# /{c=substr($$0,3); next} /^[a-zA-Z_][a-zA-Z0-9_.-]*:/{if(c!=""){t=$$1; sub(/:.*/,"",t); printf "  %-20s %s\n", t, c}; c=""; next} {c=""}' $(MAKEFILE_LIST)
 
 .SECONDEXPANSION:
 $(CMOC_OUTDIR):


### PR DESCRIPTION
## Summary
- Add `.PHONY` declarations to the seven makefiles that were missing them (`cgfx/`, `lib/`, `unittest/`, `utils/ed/`, `utils/uemacs/`, `utils/rogue_epyx_c/`, `utils/uucpbb/`)
- Add a `help` target to every makefile that prints the available phony targets along with one-line descriptions
- Embed each target's help text as a `# ...` comment immediately preceding the target rule; `make help` parses these via awk

Running `make help` in any directory now prints something like:
```
Available targets:
  all                  Build libs, tests, and utils (default target)
  libs                 Build the lib/ and cgfx/ static libraries
  ...
  help                 Display this help message listing available phony targets
```

## Test plan
- [x] `make help` in repo root lists all top-level phony targets
- [x] `make help` in each of `cgfx/`, `lib/`, `unittest/`, `utils/`, `utils/ed/`, `utils/uemacs/`, `utils/rogue_epyx_c/`, `utils/uucpbb/` lists that directory's phony targets
- [ ] Confirm existing build flows (`make`, `make clean`, etc.) still behave unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)