### PR TITLE
Add OS-9 screen size status wrapper

### DIFF
--- a/include/os.h
+++ b/include/os.h
@@ -279,6 +279,16 @@ error_code _os_gs_devnm(path_id path, char *name);
 error_code _os_gs_fd(path_id path, void *buffer, int *count);
 
 /**
+ * @brief Read the screen size reported by `SS_ScSiz`.
+ *
+ * @param path Open path descriptor, usually standard output.
+ * @param width Receives the screen width in character columns.
+ * @param height Receives the screen height in character rows.
+ * @return `0` on success, otherwise an OS-9 error code.
+ */
+error_code _os_gs_scsiz(path_id path, int *width, int *height);
+
+/**
  * @brief Write a path options packet using `SS_Opt`.
  *
  * @param path Open path descriptor.

--- a/include/os9.d
+++ b/include/os9.d
@@ -69,3 +69,4 @@ SS_ELog             equ       $19       ; error log command
 SS_SSig             equ       $1A       ; send signal command
 SS_Relea            equ       $1B       ; release command
 SS_Attr             equ       $1C       ; path attribute command
+SS_ScSiz            equ       $26       ; screen size query

--- a/lib/os_gs_ss.as
+++ b/lib/os_gs_ss.as
@@ -11,6 +11,7 @@ __os_gs_eof         EXPORT    ;         export modern eof wrapper
 __os_gs_popt        EXPORT    ;         export modern path-options getter
 __os_gs_devnm       EXPORT    ;         export modern device-name getter
 __os_gs_fd          EXPORT    ;         export modern file-descriptor getter
+__os_gs_scsiz       EXPORT    ;         export modern screen-size getter
 __os_ss_popt        EXPORT    ;         export modern path-options setter
 __os_ss_pfd         EXPORT    ;         export modern file-descriptor setter
 __os_ss_sendsig     EXPORT    ;         export modern send-signal setter
@@ -124,6 +125,22 @@ stk_os_gs_fd_count  equ       6         ; count pointer for descriptor bytes
                     ldy       stk_os_gs_fd_count+2,s ; load byte-count pointer
                     os9       I_GetStt  ; read descriptor bytes into caller buffer
                     puls      y         ; restore preserved register
+                    lbra      _osret    ; return error_code status
+
+__os_gs_scsiz:
+stk_os_gs_scsiz_ret equ       0         ; caller return address
+stk_os_gs_scsiz_path equ       2         ; path descriptor argument
+stk_os_gs_scsiz_path_byte equ       3         ; low byte passed to OS-9 in A
+stk_os_gs_scsiz_width equ       4         ; destination width pointer
+stk_os_gs_scsiz_height equ       6         ; destination height pointer
+                    pshs      y         ; preserve Y across the system call
+                    ldb       #SS_ScSiz ; request screen dimensions
+                    lda       stk_os_gs_scsiz_path_byte+2,s ; pass path descriptor in A
+                    os9       I_GetStt  ; returns width in X and height in Y
+                    bcs       GSScSiz_01 ; skip stores when OS-9 reports an error
+                    stx       [stk_os_gs_scsiz_width+2,s] ; store returned screen width
+                    sty       [stk_os_gs_scsiz_height+2,s] ; store returned screen height
+GSScSiz_01          puls      y         ; restore preserved register
                     lbra      _osret    ; return error_code status
 
 GSBuf_01


### PR DESCRIPTION
## Overview

Adds a CMOC OS-9 library wrapper for the `SS_ScSiz` GetStat call so programs can query screen dimensions through `_os_gs_scsiz()`.

The change also defines `SS_ScSiz` in the OS-9 constants header and exports the new assembly wrapper alongside the existing GetStat/SetStat helpers.

## Notable Changes

- Declares `_os_gs_scsiz(path, width, height)` in `include/os.h`.
- Adds the `SS_ScSiz` status code to `include/os9.d`.
- Implements and exports `__os_gs_scsiz` in `lib/os_gs_ss.as`, storing width and height only on successful `I_GetStt`.

## Verification

```sh
make lib
```

Verified output:

```text
cd obj_base && lwasm  ../os_gs_ss.as --obj -oos_gs_ss.o
cd obj_float && lwasm  ../os_gs_ss.as --obj -oos_gs_ss.o
```

The library build completed successfully.