### PR TITLE
Headless MAME unit-test runner + CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,10 +10,45 @@ jobs:
   check-build:
     runs-on: ubuntu-latest
     container:
-      image: jamieleecho/coco-dev:0.81
+      image: jamieleecho/coco-dev:0.82
     steps:
       - uses: actions/checkout@v6.0.2
 
       - name: Check compile
         run: |
           make tests
+
+  unit-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    container:
+      image: jamieleecho/coco-dev:0.82
+    steps:
+      - name: Checkout cmoc_os9
+        uses: actions/checkout@v6.0.2
+
+      # The disk recipe pulls modules/commands from a full NitrOS-9 checkout.
+      # Pinned for reproducibility; bump to track upstream.
+      - name: Checkout NitrOS-9
+        uses: actions/checkout@v6.0.2
+        with:
+          repository: nitros9project/nitros9
+          ref: cba089576bc761d8089755ecc23048fa5e67777b
+          path: nitros9
+
+      # CoCo 3 ROMs are copyrighted and not shipped in the image; fetch at runtime.
+      - name: Fetch CoCo 3 ROMs
+        run: |
+          mkdir -p roms
+          curl -fL --retry 3 -o roms/coco3.zip \
+            https://archive.org/download/batov39/coco3.zip
+
+      # Boots the test disk in headless MAME once per test and gates pass/fail.
+      # Known-failing tests are quarantined in recipes/coco3/known-failures, so
+      # this fails only on regressions.
+      - name: Run unit tests (headless MAME)
+        env:
+          NITROS9DIR: ${{ github.workspace }}/nitros9
+          MAME_ROMPATH: ${{ github.workspace }}/roms
+          CI_JOBS: "2"
+        run: make test-ci

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 # Top-level build driver for the CMOC OS-9 library, tests, and utilities.
 
 .PHONY: all libs tests utils clean clean-libs clean-tests clean-utils \
-        clean-recipe dsk run unittest-dsk unittest-run lib cgfx unittest help
+        clean-recipe dsk run unittest-dsk unittest-run lib cgfx unittest \
+        test-ci help
 
 # Build libs, tests, and utils (default target)
 all: libs tests utils
@@ -40,6 +41,22 @@ run:
 # Build the standalone unit-test disk and launch MAME
 unittest-run: libs
 	$(MAKE) -C unittest run
+
+# Headless MAME settings for test-ci. Requires `mame` (coco3 build) and `os9` on
+# PATH -- i.e. run inside the jamieleecho/coco-dev image -- and MAME_ROMPATH set
+# to a directory with a coco3 romset (coco3.rom plus a disk controller rom).
+CI_DISK        := recipes/coco3/l2_coco3_cmoc_os9.dsk
+CI_BUDGET      ?= 120
+CI_BUDGET_SLOW ?= 600
+CI_JOBS        ?= 4
+
+# Run the unit tests headlessly (one MAME boot per test), gating pass/fail
+test-ci:
+	@test -n "$(MAME_ROMPATH)" || { echo "ERROR: set MAME_ROMPATH to a dir with a coco3 romset"; exit 2; }
+	$(MAKE) dsk
+	DISK_SRC=$(CI_DISK) ROMPATH=$(MAME_ROMPATH) \
+	  BUDGET=$(CI_BUDGET) BUDGET_SLOW=$(CI_BUDGET_SLOW) JOBS=$(CI_JOBS) \
+	  bash recipes/coco3/citest.sh
 
 # Remove build artifacts in libs, tests, and utils
 clean: clean-tests clean-utils clean-libs clean-recipe

--- a/recipes/coco3/README.md
+++ b/recipes/coco3/README.md
@@ -6,6 +6,7 @@ Files here:
 - `nitros9.mak`: CMOC OS-9 build and disk population rules.
 - `startup`: minimal boot script copied onto the test disk as `startup`.
 - `test`: manual regression batch script copied onto the disk when needed.
+- `citest.sh`: headless CI runner used by `make test-ci` (see below).
 
 The recipe still consumes modules, commands, libraries, and disk tools from a
 nearby NitrOS-9 checkout. By default it looks for that checkout at
@@ -25,3 +26,40 @@ make
 ```
 
 The default output is `l2_coco3_cmoc_os9.dsk` in this directory.
+
+## Headless automated testing (`make test-ci`)
+
+`citest.sh` runs the unit tests automatically and headlessly: it boots the test
+disk in MAME **once per test** (full isolation, so a hanging or crashing test
+can't block the others), captures each test's output from the disk, and reports
+`PASS` / `FAIL` / `TIMEOUT`. It exits non-zero if any test fails or times out.
+
+Each test runs with a fast emulated-second budget and is retried once at a
+larger budget only if it times out, so a genuinely slow test (e.g. `iotest`,
+which does heavy floppy I/O) is not confused with a hang.
+
+This needs `mame` (a coco3 build) and ToolShed `os9` on `PATH` — i.e. the
+[`jamieleecho/coco-dev`](https://github.com/jamieleecho/coco-dev) image — plus a
+CoCo 3 romset (not shipped: `coco3.rom` and a disk-controller rom such as
+`disk11.rom`). From the repository root:
+
+```sh
+# inside the coco-dev container, with a NitrOS-9 checkout and ROMs available
+make test-ci MAME_ROMPATH=/path/to/roms
+```
+
+Run it from the host via the container, mounting this repo, a NitrOS-9 checkout,
+and the romset:
+
+```sh
+docker run --rm \
+  -e NITROS9DIR=/src/nitros9 -e MAME_ROMPATH=/roms \
+  -v "$PWD":/src/cmoc_os9 -v /path/to/nitros9:/src/nitros9 \
+  -v /path/to/roms:/roms:ro -w /src/cmoc_os9 \
+  jamieleecho/coco-dev make test-ci
+```
+
+Knobs (Make variables / env): `CI_JOBS` (parallel tests, default 4),
+`CI_BUDGET` (fast per-test emulated seconds, default 120), `CI_BUDGET_SLOW`
+(timeout-retry budget, default 600). Per-test output is left in a temporary
+`RESULTS` directory printed at the end.

--- a/recipes/coco3/citest.sh
+++ b/recipes/coco3/citest.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+#
+# Headless CI runner for the cmoc_os9 unit tests.
+#
+# Boots the CoCo 3 NitrOS-9 test disk in MAME once per test (full isolation, so
+# a hanging or crashing test cannot block the others), captures each test's
+# output from the disk, and reports PASS / FAIL / TIMEOUT. Exits non-zero if any
+# test fails or times out.
+#
+# Must run in an environment that has `mame` (a coco3-capable build) and the
+# ToolShed `os9` tool on PATH -- i.e. inside the jamieleecho/coco-dev image.
+# ROMs are NOT shipped with that image; point ROMPATH at a directory containing
+# a coco3 romset (coco3.rom + a disk controller rom).
+#
+# Usage:
+#   DISK_SRC=path/to/l2_coco3_cmoc_os9.dsk ROMPATH=/roms bash citest.sh
+#   citest.sh --one <testname>      # run a single test (used internally per job)
+#
+# Environment knobs:
+#   DISK_SRC      bootable test disk image (required)
+#   ROMPATH       MAME rompath with a coco3 romset (required)
+#   TEST_SCRIPT   file to derive the test list from (default: ./test next to this script)
+#   TESTS         explicit space-separated test list (overrides TEST_SCRIPT)
+#   BUDGET        fast per-test emulated-second budget (default 120)
+#   BUDGET_SLOW   escalation budget retried once on a fast timeout (default 600)
+#   DELAY         MAME autoboot delay in seconds before typing DOS (default 8)
+#   JOBS          number of tests to run concurrently (default 4)
+#   RESULTS       directory for per-test .out files and statuses (default: mktemp)
+#   KNOWN_FAILURES        space-separated tests that may fail without failing the
+#                         run (quarantine); reported as XFAIL. Overrides the file.
+#   KNOWN_FAILURES_FILE   file of quarantined test names, one per line, '#'
+#                         comments allowed (default: ./known-failures next to this)
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+: "${BUDGET:=120}"
+: "${BUDGET_SLOW:=600}"
+: "${DELAY:=8}"
+: "${JOBS:=4}"
+: "${TEST_SCRIPT:=$SCRIPT_DIR/test}"
+
+# Boot the disk once, running exactly one test, with a given emulated-second
+# budget. Leaves <test>.out and the zzdone sentinel on the returned disk copy.
+# Echoes "COMPLETED" or "TIMEOUT".
+run_once() {
+	local test=$1 budget=$2 disk=$3
+	local mdir; mdir=$(dirname "$disk")
+	cp "$DISK_SRC" "$disk"
+	{
+		printf 'echo * %s *\nlink shell\nload utilpak1\n' "$test"
+		printf '%s >>>-%s.out\n' "$test" "$test"
+		printf 'echo CIDONE >>>-zzdone.out\n'
+	} >"$disk.startup"
+	os9 copy -l -r "$disk.startup" "$disk,startup" >/dev/null 2>&1
+	os9 attr -q -npe -npw -pr -ne -w -r "$disk,startup" >/dev/null 2>&1
+	SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy \
+		mame coco3 -rompath "$ROMPATH" -skip_gameinfo \
+			-ext fdc -ext:fdc:wd17xx:0 525qd -flop1 "$disk" \
+			-video none -sound none -nothrottle \
+			-cfg_directory "$mdir/cfg" -nvram_directory "$mdir/nvram" \
+			-snapshot_directory "$mdir/snap" -comment_directory "$mdir/cmt" \
+			-autoboot_delay "$DELAY" -autoboot_command "DOS\n" \
+			-seconds_to_run "$budget" >/dev/null 2>&1
+	if os9 dir "$disk" 2>/dev/null | grep -q zzdone; then echo COMPLETED; else echo TIMEOUT; fi
+}
+
+# Run a single test: fast budget, escalate to the slow budget on timeout (to
+# tell a genuinely slow test apart from a hang). Writes RESULTS/<test>.out and
+# RESULTS/<test>.status.
+run_one() {
+	local test=$1
+	local disk; disk=$(mktemp -u)/d.dsk; mkdir -p "$(dirname "$disk")"
+	local state; state=$(run_once "$test" "$BUDGET" "$disk")
+	if [ "$state" = TIMEOUT ]; then state=$(run_once "$test" "$BUDGET_SLOW" "$disk"); fi
+	os9 list "$disk,$test.out" >"$RESULTS/$test.out" 2>/dev/null || : >"$RESULTS/$test.out"
+	local status
+	if [ "$state" = TIMEOUT ]; then
+		status=TIMEOUT
+	else
+		local nf; nf=$(grep -c '\[FAIL\]' "$RESULTS/$test.out" 2>/dev/null) || true
+		[ "${nf:-0}" -gt 0 ] && status="FAIL[$nf]" || status=PASS
+	fi
+	echo "$status" >"$RESULTS/$test.status"
+	rm -rf "$(dirname "$disk")"
+}
+
+# --- single-test mode (invoked per job) ---
+if [ "${1:-}" = --one ]; then
+	: "${DISK_SRC:?need DISK_SRC}"; : "${ROMPATH:?need ROMPATH}"; : "${RESULTS:?need RESULTS}"
+	run_one "$2"
+	exit 0
+fi
+
+# --- orchestrator mode ---
+: "${DISK_SRC:?need DISK_SRC (bootable test disk)}"
+: "${ROMPATH:?need ROMPATH (dir with a coco3 romset)}"
+[ -f "$DISK_SRC" ] || { echo "DISK_SRC not found: $DISK_SRC" >&2; exit 2; }
+
+if [ -z "${TESTS:-}" ]; then
+	[ -f "$TEST_SCRIPT" ] || { echo "TEST_SCRIPT not found: $TEST_SCRIPT" >&2; exit 2; }
+	TESTS=$(awk '/>>>/{print $1}' "$TEST_SCRIPT")
+fi
+
+export RESULTS="${RESULTS:-$(mktemp -d)}"
+mkdir -p "$RESULTS"
+export DISK_SRC ROMPATH BUDGET BUDGET_SLOW DELAY
+
+ntests=$(echo $TESTS | wc -w | tr -d ' ')
+echo "Running $ntests tests, $JOBS at a time (budget ${BUDGET}s, escalate ${BUDGET_SLOW}s)..."
+printf '%s\n' $TESTS | xargs -P "$JOBS" -I{} bash "${BASH_SOURCE[0]}" --one {}
+
+# Load the quarantine list (known failures reported but not gated).
+: "${KNOWN_FAILURES_FILE:=$SCRIPT_DIR/known-failures}"
+if [ -n "${KNOWN_FAILURES:-}" ]; then
+	known=" $KNOWN_FAILURES "
+elif [ -f "$KNOWN_FAILURES_FILE" ]; then
+	known=" $(sed 's/#.*//' "$KNOWN_FAILURES_FILE" | tr '\n' ' ') "
+else
+	known=" "
+fi
+is_known() { case "$known" in *" $1 "*) return 0 ;; *) return 1 ;; esac; }
+
+# Aggregate, preserving the test-script order.
+pass=0; xfail=0; failed=()
+echo
+echo "==================== RESULTS ===================="
+for t in $TESTS; do
+	st=$(cat "$RESULTS/$t.status" 2>/dev/null || echo "NO-RESULT")
+	note=""
+	if [ "$st" = PASS ]; then
+		pass=$((pass+1))
+		is_known "$t" && note="  <- listed in known-failures but passing; consider removing"
+	elif is_known "$t"; then
+		xfail=$((xfail+1)); st="XFAIL[$st]"
+	else
+		failed+=("$t:$st")
+	fi
+	printf '  %-18s %s%s\n' "$t" "$st" "$note"
+done
+echo "================================================="
+echo "PASS: $pass / $ntests   XFAIL(known): $xfail   (per-test output in $RESULTS)"
+if [ ${#failed[@]} -gt 0 ]; then
+	echo "UNEXPECTED FAILURES: ${failed[*]}"
+	exit 1
+fi
+echo "No unexpected failures."

--- a/recipes/coco3/known-failures
+++ b/recipes/coco3/known-failures
@@ -1,0 +1,19 @@
+# Tests that currently hang or fail under headless NitrOS-9 in MAME.
+#
+# Listed here so `make test-ci` gates on regressions (any OTHER test failing
+# fails the run) without being permanently red on these known issues. They are
+# reported as XFAIL. Remove an entry once its underlying bug is fixed -- if a
+# listed test starts passing, the runner flags it so you know to clean it up.
+#
+# One test name per line; '#' begins a comment.
+
+# Hangs at exit, after test_freopen_failure_keeps_stream_usable prints its last
+# assertion (fclose / unlink / C-runtime stdio cleanup). Also asserts that
+# open(".", FAM_READ) >= 0, which NitrOS-9 does not allow.
+fdstreamtest
+
+# Hangs around test_putw / getw().
+fiotest
+
+# Hangs after test_crc. Also fails test_prerr (prerr()).
+misctest


### PR DESCRIPTION
Adds automated, headless unit-test runs in MAME and wires them into CI.

- **`make test-ci`** builds the CoCo 3 NitrOS-9 test disk and boots it in headless MAME **once per test** (full isolation, so a hang can't block the rest), captures each test's output, and gates pass/fail. Slow tests retry at a larger time budget so they aren't mistaken for hangs; tests run in parallel (`CI_JOBS`). Runs in the `coco-dev` image; needs `MAME_ROMPATH`.
- **CI** (`unit-tests` job in `build.yml`) runs it on `coco-dev:0.82` against a pinned NitrOS-9 checkout and a fetched CoCo 3 romset.

### Known-failing tests (quarantined)
Listed in `recipes/coco3/known-failures`, reported as `XFAIL`, and do **not** fail CI — so CI is green on this baseline and red on regressions. Remove an entry once fixed:

- **`fdstreamtest`** — hangs at exit (stdio/file cleanup); also asserts `open(".", FAM_READ) >= 0`, which NitrOS-9 rejects.
- **`fiotest`** — hangs around `putw`/`getw`.
- **`misctest`** — hangs after `test_crc`; also fails `test_prerr` (`prerr()`).

Current baseline: **49 PASS / 3 XFAIL**.

> Requires `jamieleecho/coco-dev:0.82` (headless MAME) to be published to Docker Hub; both CI jobs reference it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)