### PR TITLE
Reject invalid fdopen() modes

### DIFF
--- a/include/fcntl.h
+++ b/include/fcntl.h
@@ -29,6 +29,7 @@
 #define	FAM_WRITE	S_IWRITE
 #define	FAM_UPDATE	(S_IREAD|S_IWRITE)
 #define	FAM_NONSHARE	S_ISHARE
+#define	FAM_DIR		S_DIR
 
 /* _os style file access permissions */
 #define	FAP_READ	0x01

--- a/lib/fopen.as
+++ b/lib/fopen.as
@@ -119,6 +119,16 @@ setiob6
                     bra       setiob8   ; merge computed mode into FILE flags
 
 setiob7
+                    cmpb      #'w       ; writable modes start with 'w'
+                    beq       setiob7a
+                    cmpb      #'a       ; ... or 'a' (append)
+                    beq       setiob7a
+                    ldd       #E_BMode  ; unsupported mode string
+                    std       _errno,y  ; report EINVAL for an unsupported mode string
+                    clra                ; return NULL high byte
+                    clrb                ; return NULL low byte
+                    rts                 ; reject the bad mode so fdopen() yields NULL
+setiob7a
                     ldb       #_WRITE   ; mark stream writable
 setiob8
                     orb       FILE_FLAG+1,u ; preserve existing low-byte FILE flags

--- a/unittest/fdstreamtest.c
+++ b/unittest/fdstreamtest.c
@@ -101,8 +101,8 @@ static void test_fdopen_badmode(void)
     FILE *fp;
 
     unlink(fdopen_read_tmp);
-    fd = open(".", FAM_READ);
-    check_true("test_fdopen_badmode open(dir)", fd >= 0);
+    fd = open(".", FAM_DIR);
+    check_true("test_fdopen_badmode open(dir)", fd > 0);
     if (fd < 0)
         return;
 


### PR DESCRIPTION
`fdopen()` skipped the mode-string validation that `fopen()`/`freopen()` do (via `openit()`), going straight to `setiob()`, whose first-character switch treated any unrecognized mode (e.g. `"q"`) as write-only and returned a non-NULL `FILE *`. Now `setiob`'s write branch accepts only `w`/`a`; any other first mode character sets `errno` to `E_BMode` and returns NULL — so `fdopen(fd, "q")` yields NULL like `fopen(path, "q")`.

Commits:
- **fix** `lib/fopen.as` — the validation.
- **test** `include/fcntl.h` (`FAM_DIR`) + `unittest/fdstreamtest.c` — `test_fdopen_badmode` now opens `.` so the dir-open succeeds and the test reaches the `fdopen(fd, "q")` check; verified `[PASS]`.

Note: `fdstreamtest` still **hangs at exit** (a separate, unrelated bug in the stdio exit-flush path), so it remains quarantined in `recipes/coco3/known-failures` and will report `XFAIL`. This PR only fixes the `fdopen` bad-mode assertion, not that hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)