### PR TITLE
Return character count from printf/fprintf/sprintf

### DIFF
--- a/lib/printf.c
+++ b/lib/printf.c
@@ -10,6 +10,7 @@
 #include <os.h>
 
 FILE *fpmp;
+int pfcount;
 char buf1[10];
 int dectbl[4]= {10000,1000,100,10};
 
@@ -97,6 +98,7 @@ prtvar  set         14          ; 2
 
 printf_common_exit
      	leas    vlen,s 
+		ldd     _pfcount,y          return count of characters written
  		rts    
 
 *    entry:  variables  fpmp  destination - string address or FILE pointer
@@ -115,6 +117,8 @@ printf_common_exit
 printf_common
  	    ldu     4,s             get format string
  		leas    -vlen,s         make room on stack
+		ldd     #0                  reset output character counter
+		std     _pfcount,y 
  		bra     L004a 
 case_c 	ldx     prtvar,s 
  		ldd     ,x++ 
@@ -426,6 +430,9 @@ put_to_file
 		pshs    d,x 
 		lbsr    putc 
 		leas    4,s 
+		ldd     _pfcount,y
+		addd    #1                  count one character written
+		std     _pfcount,y
 		rts    
 
 * B = character to put
@@ -434,6 +441,9 @@ put_to_mem
 		stb     ,x+ 
 		stx     _fpmp,y 
 		clr     ,x
+		ldd     _pfcount,y
+		addd    #1                  count one character written
+		std     _pfcount,y
 		rts
 	}
 }


### PR DESCRIPTION
`printf`/`fprintf`/`sprintf` never returned a character count — the asm core in `lib/printf.c` emits characters through its output handlers but never counts them, so `printf_common_exit` returned whatever leftover value was in `D`. In practice that was `<= 0` for a plain format string and `> 0` only when a conversion left something positive behind:

- `fprintf(fp, "plain string")` → returned `<= 0`
- `fprintf(fp, "...%s...", arg)` → returned `> 0`

Per C, both should return the number of characters written.

**Fix:** add a `pfcount` counter — reset on entry to `printf_common`, incremented in both output handlers (`put_to_file` and `put_to_mem`, so stdout, files, and `sprintf` all count), and returned at `printf_common_exit`.

Verified against `unittest/fiotest`: every `printf`/`fprintf` assertion in `test_text_output` now passes (previously the plain-string `printf()`/`fprintf(world)` cases failed).

Found by running `fiotest` on a real CoCo 3 MAME and capturing its output. (Note: `fiotest` also has separate, unrelated issues — a `puts()` return value and a `content` mismatch — not addressed here; and it hangs only under stock headless MAME, which is a MAME-emulation difference, not a library bug.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)