### PR TITLE
Make puts() return a non-negative value on success

### DIFF
--- a/lib/puts.as
+++ b/lib/puts.as
@@ -16,8 +16,10 @@ stk_puts_string     equ       2         ; string pointer argument
                     ldd       stk_puts_string+2,s ; load string pointer after saved U
                     pshs      d,x       ; stage string and stdout for fputs/putc calls
                     lbsr      _fputs    ; emit the string body through stdio
-                    ldb       #$0D      ; append OS-9 carriage return for puts()
-                    stb       1,s       ; replace staged low byte with newline character
+                    ldd       #$000D    ; append OS-9 carriage return as a full int
+                    std       ,s        ; replace staged char (zero high byte so putc
+*                                       ; returns the non-negative character, not the
+*                                       ; sign-extended high byte of the string pointer)
                     lbsr      _putc     ; emit trailing carriage return to stdout
                     leas      4,s       ; discard staged string/stdout arguments
                     puls      u,pc      ; restore registers and return


### PR DESCRIPTION
`puts()` staged the trailing carriage return for `putc()` by overwriting only the *low* byte of the already-staged string pointer (`stb 1,s`), leaving the pointer's high byte in place. Since `putc()` returns the full `int` it is passed (`ldd stk_putc_char+2,s`), `puts()` then returned a value whose high byte was the string pointer's high byte — **negative whenever the string lives in high memory** (the usual case for OS-9 program data). So `puts()` reported failure (`< 0`) even though it wrote the line correctly.

**Fix:** stage the carriage return as a clean `int` (zero high byte) so `putc()` returns the non-negative character and `puts()` returns `>= 0` on success.

Verified against `unittest/fiotest`: `test_stdout_puts puts()` now passes (the text was always written; only the return value was wrong).

🤖 Generated with [Claude Code](https://claude.com/claude-code)