### PR TITLE
Fix undersized read buffer in fiotest test_text_output

### DIFF
--- a/unittest/fiotest.c
+++ b/unittest/fiotest.c
@@ -20,7 +20,7 @@ static void check_true(const char *name, int condition)
 static void test_text_output(void)
 {
     FILE *fp;
-    char buf[128];
+    char buf[256];
     size_t n;
     const char expected[] =
         "123\n"


### PR DESCRIPTION
`test_text_output` writes 192 bytes to a temp file, reads it back into `buf`, and compares against the 192-byte `expected` string — but `buf` was only `char[128]`. `fread(buf, 1, sizeof(buf)-1, fp)` therefore read back just 127 bytes, so `strcmp(buf, expected)` could never match and `content` always failed.

This is a flaw in the test, not the library: the file is written **byte-for-byte correctly** (verified by extracting it and diffing against `expected`). Enlarge `buf` to `char[256]` so the whole file is read back for comparison.

With this (and the related `printf`/`puts` return-value fixes in #23/#24), every assertion in `fiotest` passes. `fiotest` remains quarantined only for a separate stock-MAME-headless hang, which is a MAME emulation difference, not a cmoc/library bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)