### PR TITLE
Make prerr() return 0 on success

### DIFF
--- a/lib/misc.as
+++ b/lib/misc.as
@@ -49,6 +49,8 @@ stk_prerr_error_byte equ       5         ; low byte of error code argument
                     ldb       stk_prerr_error_byte,s ; pass error code to print
                     os9       F_PErr    ; ask OS-9 to print the error text
                     lblo      _os9err   ; return OS-9 failure through error helper
+                    clra                ; return 0 on success (D held path:errcode)
+                    clrb
                     rts                 ; return to caller
 
 _tsleep:


### PR DESCRIPTION
`prerr()` fell through to `rts` after the `F$PErr` system call without setting a return value, so it returned whatever was left in `D` — the packed `path:errcode`. For example `prerr(2, 216)` returned `0x02D8` (728). Callers that check for `0` (per the `int prerr(int filenum, int errcode)` contract) therefore saw a spurious failure, even though the OS-9 error text was printed correctly.

**Fix:** clear `D` (`clra`/`clrb`) on the success path before `rts`, so `prerr()` returns 0 on success (and `-1` via `_os9err` on failure, unchanged).

Verified against `unittest/misctest`: `test_prerr prerr()` now passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)