### PR TITLE
Add MAME ROM path to recipe run flags

### DIFF
--- a/recipes/coco3/nitros9.mak
+++ b/recipes/coco3/nitros9.mak
@@ -88,7 +88,7 @@ $(DSKIMAGE): kernelfile bootfile $(MODDIR)/$(CMOC_OS9_SYSGO) $(addprefix $(MODDI
 
 MAME         ?= mame
 MAME_MACHINE ?= coco3
-MAME_FLAGS   ?= -window -nothrottle -skip_gameinfo -autoboot_delay 5 -autoboot_command "DOS\n" -ext fdc -ext:fdc:wd17xx:0 525qd
+MAME_FLAGS   ?= -rompath $(MAME_ROM_PATH) -window -nothrottle -skip_gameinfo -autoboot_delay 5 -autoboot_command "DOS\n" -ext fdc -ext:fdc:wd17xx:0 525qd
 
 run: $(DSKIMAGE)
 	$(MAME) $(MAME_MACHINE) $(MAME_FLAGS) -flop1 $(DSKIMAGE)


### PR DESCRIPTION
## Overview

Adds the configured `MAME_ROM_PATH` to the default MAME flags used by the CoCo 3 recipe `run` target. This lets `make run MAME_ROM_PATH=/path/to/roms` pass the ROM directory directly to MAME instead of relying on host defaults.

## Notable Changes

- Adds `-rompath $(MAME_ROM_PATH)` to `MAME_FLAGS` in `recipes/coco3/nitros9.mak`.
- Leaves the existing machine, autoboot, and floppy-controller flags unchanged.

## Verification

```sh
git diff --check origin/master...HEAD
make -n run MAME_ROM_PATH=/roms
```

Verified the dry-run MAME command ends with:

```text
mame coco3 -rompath /roms -window -nothrottle -skip_gameinfo -autoboot_delay 5 -autoboot_command "DOS\n" -ext fdc -ext:fdc:wd17xx:0 525qd -flop1 l2_coco3_cmoc_os9.dsk
```

Full MAME execution was not run; this change only affects the generated invocation flags.